### PR TITLE
fix: failed to run yarn user-bot info -f Ftest

### DIFF
--- a/packages/fasset-bots-core/run-config/coston-bot.json
+++ b/packages/fasset-bots-core/run-config/coston-bot.json
@@ -91,7 +91,7 @@
             }
         }
     },
-    "rpcUrl": "https://coston-api-tracer.flare.network/ext/C/rpc",
+    "rpcUrl": "https://coston-api.flare.network/ext/C/rpc",
     "dataAccessLayerUrls": [
         "https://da.cflr.testfsp.aflabs.org:4443"
     ],


### PR DESCRIPTION
I run `yarn user-bot info -f FtestXRP` failed with error `Error: Invalid JSON RPC response: ""`

After update rpcUrl, I can run `yarn user-bot info -f FtestXRP` successfully